### PR TITLE
ADD license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "name": "Oliver Leics",
     "email": "oliver.leics@gmail.com"
   },
+  "license": "MIT",
   "name": "tinyforever",
   "version": "0.0.3",
   "repository": {


### PR DESCRIPTION
ADD license field to `package.json` so tools can determine what Licence the software is under.

[DependencyCI](https://dependencyci.com) uses this field to warn consumers of packages that are unlicensed, unmaintained etc.
